### PR TITLE
Delete .github/ISSUE_TEMPLATE/issue-contents.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-contents.md
+++ b/.github/ISSUE_TEMPLATE/issue-contents.md
@@ -1,8 +1,0 @@
-### On-chain address for first allocation
-f1thcqx65vybwwfhdxr5umn77sogf7zyrokmvg2mq
-
-### Total amount of DataCap being requested
-123TiB
-
-### Weekly allocation of DataCap requested
-123TiB


### PR DESCRIPTION
The presence of this file appears to interfere with the ability to select the pre-configured .yaml file as an issue template.